### PR TITLE
fix:  add default newInsecureDefaultClient

### DIFF
--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
 	"github.com/moby/buildkit/util/progress/progresswriter"
+	"github.com/moby/buildkit/util/resolver"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/nacl/sign"
 	"google.golang.org/grpc"
@@ -94,7 +95,7 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 		Secret:   creds.Secret,
 	}
 
-	var httpClient = http.DefaultClient()
+	var httpClient = resolver.NewInsecureDefaultClient()
 	if tc, err := ap.tlsConfig(req.Host); err == nil && tc != nil {
 		transport := http.DefaultTransport()
 		transport.TLSClientConfig = tc

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -121,7 +121,7 @@ func (p *Pool) GetResolver(hosts docker.RegistryHosts, ref, scope string, sm *se
 func newResolver(hosts docker.RegistryHosts, handler *authHandlerNS, sm *session.Manager, g session.Group) *Resolver {
 	if hosts == nil {
 		hosts = docker.ConfigureDefaultRegistries(
-			docker.WithClient(newDefaultClient()),
+			docker.WithClient(NewInsecureDefaultClient()),
 			docker.WithPlainHTTP(docker.MatchLocalhost),
 		)
 	}

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -153,7 +153,7 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 
 			h := docker.RegistryHost{
 				Scheme:       "https",
-				Client:       newDefaultClient(),
+				Client:       NewInsecureDefaultClient(),
 				Host:         host,
 				Path:         "/v2",
 				Capabilities: docker.HostCapabilityPush | docker.HostCapabilityPull | docker.HostCapabilityResolve,
@@ -169,7 +169,7 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 			return out, nil
 		},
 		docker.ConfigureDefaultRegistries(
-			docker.WithClient(newInsecureDefaultClient()),
+			docker.WithClient(NewInsecureDefaultClient()),
 			docker.WithPlainHTTP(isPlainHTTP),
 		),
 	)
@@ -244,7 +244,7 @@ func newMirrorRegistryHost(mirror string) docker.RegistryHost {
 	path := path.Join(defaultPath, mirrorPath)
 	h := docker.RegistryHost{
 		Scheme:       "https",
-		Client:       newDefaultClient(),
+		Client:       NewInsecureDefaultClient(),
 		Host:         mirrorHost,
 		Path:         path,
 		Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
@@ -253,7 +253,7 @@ func newMirrorRegistryHost(mirror string) docker.RegistryHost {
 	return h
 }
 
-func newInsecureDefaultClient() *http.Client {
+func NewInsecureDefaultClient() *http.Client {
 	httpsTransport := newDefaultTransport()
 	httpsTransport.TLSClientConfig = &tls.Config{}
 	httpsTransport.TLSClientConfig.InsecureSkipVerify = true


### PR DESCRIPTION
![image](https://github.com/alauda/buildkit/assets/22126779/8fd7123f-cf92-4de4-8ddc-a3d741836256)

某些请求没有用regsitry client 初始化的 client处理，可能出现x509 的问题。 

全部替换后，测试可以通过验证。

效果类似于文档的这个配置：
https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md
![image](https://github.com/alauda/buildkit/assets/22126779/86b7e93f-3c78-471e-bc94-feea27f48404)
